### PR TITLE
docs: add focused issue-fix task list from codebase review

### DIFF
--- a/docs/2026-05-05-codebase-issue-tasks.md
+++ b/docs/2026-05-05-codebase-issue-tasks.md
@@ -1,0 +1,44 @@
+# Codebase issue triage (2026-05-05)
+
+## 1) Typo fix task
+**Issue:** `README.md` contains a malformed relative path (`docs/..`) in the sentence that points readers to documentation order.
+
+**Task:** Replace `docs/..` with a valid path (likely `docs/README-order.md`) and verify the sentence reads cleanly.
+
+**Acceptance criteria:**
+- The incorrect `docs/..` fragment is removed.
+- The documentation pointer is unambiguous and clickable in GitHub preview.
+
+## 2) Bug fix task
+**Issue:** In the server-side web API helper, `content-type: application/json` is always set even when `FormData` bodies may be passed. This can break multipart boundaries and file upload behavior.
+
+**Task:** Update `apps/web/lib/api.ts` to mirror the safer logic used in `apps/web/lib/use-api.ts`: only set JSON `content-type` when the request body is not `FormData` and no explicit content-type is already present.
+
+**Acceptance criteria:**
+- `apiFetch` does not force JSON content-type for multipart requests.
+- Existing JSON calls still work without callers setting headers manually.
+- Add or update unit/integration coverage around header behavior.
+
+## 3) Documentation discrepancy task
+**Issue:** Root `README.md` states "Phase 6 onwards ... is not yet implemented," but the repository already contains Phase 6+ modules (compliance, analytics, white-label, billing) in `apps/api/src/`.
+
+**Task:** Reconcile README status text with actual implementation state by either:
+- updating the phase-completion summary, or
+- explicitly listing what's partial vs complete.
+
+**Acceptance criteria:**
+- README status section matches current code reality.
+- Any unfinished areas are marked as partial instead of blanket "not implemented."
+
+## 4) Test improvement task
+**Issue:** `apps/api/src/calls/calls.service.ts` swallows transcript-provider errors in `get()` via a bare `catch` and silently returns empty turns. This behavior is intentional for resilience, but there is no explicit regression test proving failure isolation.
+
+**Task:** Add a unit test for `CallsService.get()` that forces `voice.getTranscript()` to throw and verifies:
+- the call detail request still succeeds,
+- `turns` is an empty array,
+- persisted `transcript_text` is still returned,
+- evaluation lookup still runs.
+
+**Acceptance criteria:**
+- New test fails before the behavior exists and passes after.
+- The resilience behavior is documented by the test name and assertions.


### PR DESCRIPTION
### Motivation
- Capture and track four actionable items found during a code review: a README typo, an API header-handling bug, a documentation-status discrepancy, and a missing resilience unit test.

### Description
- Add `docs/2026-05-05-codebase-issue-tasks.md` which lists four concise tasks: fix the `docs/..` README typo, update `apps/web/lib/api.ts` to avoid forcing `content-type: application/json` for `FormData` requests, reconcile the README Phase-6 status with existing Phase 6+ modules, and add a unit test for `CallsService.get()` to assert resilience when `voice.getTranscript()` throws.

### Testing
- Performed automated repository inspections and file reads using `rg`, `sed`, and `nl` to locate occurrences, verify contents, and confirm the new doc file exists, and all commands completed successfully; no unit test suite runs were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa04b0e514832b89fb88824a0529cd)