### PR TITLE
fix(auth): handle P2002 race condition + fix SSR crashes on all dashboard pages

### DIFF
--- a/apps/api/src/auth/clerk-auth.service.ts
+++ b/apps/api/src/auth/clerk-auth.service.ts
@@ -156,6 +156,13 @@ export class ClerkAuthService extends AuthService {
     if (existing) return existing;
 
     if (!this.client) {
+      const fallback = await this.prisma.user.findUnique({ where: { email: `${clerkUserId}@clerk.invalid` } });
+      if (fallback) {
+        if (!fallback.externalAuthId) {
+          return this.prisma.user.update({ where: { id: fallback.id }, data: { externalAuthId } });
+        }
+        return fallback;
+      }
       return this.prisma.user.create({
         data: { externalAuthId, email: `${clerkUserId}@clerk.invalid`, name: null },
       });
@@ -165,14 +172,41 @@ export class ClerkAuthService extends AuthService {
     const email = clerkUser.emailAddresses[0]?.emailAddress ?? `${clerkUserId}@clerk.invalid`;
     const name = [clerkUser.firstName, clerkUser.lastName].filter(Boolean).join(' ') || clerkUser.username || null;
 
-    const user = await this.prisma.user.upsert({
-      where: { externalAuthId },
-      create: { externalAuthId, email, name },
-      update: { email, name },
-    });
+    // Check if user already exists by email (webhook may have created it first)
+    const byEmail = await this.prisma.user.findUnique({ where: { email } });
+    if (byEmail) {
+      if (!byEmail.externalAuthId || byEmail.externalAuthId === externalAuthId) {
+        const user = await this.prisma.user.update({
+          where: { id: byEmail.id },
+          data: { externalAuthId, name },
+        });
+        await this.provisionOrgWorkspace(user.id, clerkOrgId);
+        return user;
+      }
+      return byEmail;
+    }
 
-    await this.provisionOrgWorkspace(user.id, clerkOrgId);
-    return user;
+    try {
+      const user = await this.prisma.user.upsert({
+        where: { externalAuthId },
+        create: { externalAuthId, email, name },
+        update: { email, name },
+      });
+      await this.provisionOrgWorkspace(user.id, clerkOrgId);
+      return user;
+    } catch (err: unknown) {
+      // Race condition: webhook created user between our check and upsert
+      const prismaErr = err as { code?: string };
+      if (prismaErr.code === 'P2002') {
+        const raced = await this.prisma.user.findUnique({ where: { email } })
+          ?? await this.prisma.user.findUnique({ where: { externalAuthId } });
+        if (raced) {
+          await this.provisionOrgWorkspace(raced.id, clerkOrgId);
+          return raced;
+        }
+      }
+      throw err;
+    }
   }
 
   private async provisionOrgWorkspace(userId: string, clerkOrgId: string | null) {

--- a/apps/api/src/auth/clerk-webhook.controller.ts
+++ b/apps/api/src/auth/clerk-webhook.controller.ts
@@ -142,11 +142,38 @@ export class ClerkWebhookController {
     const name =
       [data.first_name, data.last_name].filter(Boolean).join(' ') || data.username || null;
 
-    await this.prisma.user.upsert({
-      where: { externalAuthId },
-      create: { externalAuthId, email, name },
-      update: { email, name },
-    });
+    // Check if user already exists by email (API request path may have created it)
+    const byEmail = await this.prisma.user.findUnique({ where: { email } });
+    if (byEmail) {
+      await this.prisma.user.update({
+        where: { id: byEmail.id },
+        data: { externalAuthId, name },
+      });
+      await this.cache.del(`session:user:${externalAuthId}`);
+      return;
+    }
+
+    try {
+      await this.prisma.user.upsert({
+        where: { externalAuthId },
+        create: { externalAuthId, email, name },
+        update: { email, name },
+      });
+    } catch (err: unknown) {
+      const prismaErr = err as { code?: string };
+      if (prismaErr.code === 'P2002') {
+        // Race condition — user was created between our check and upsert
+        const raced = await this.prisma.user.findUnique({ where: { email } });
+        if (raced) {
+          await this.prisma.user.update({
+            where: { id: raced.id },
+            data: { externalAuthId, name },
+          });
+        }
+      } else {
+        throw err;
+      }
+    }
 
     await this.cache.del(`session:user:${externalAuthId}`);
   }

--- a/apps/web/app/dashboard/agents/page.tsx
+++ b/apps/web/app/dashboard/agents/page.tsx
@@ -7,11 +7,39 @@ import type { AgentSummary, SessionUser } from '@voiceforge/shared';
 import { Bot, Plus, ArrowRight } from 'lucide-react';
 
 export default async function AgentsPage() {
-  const me = await apiFetch<SessionUser>('/auth/me');
-  const res = await apiFetch<{ items: AgentSummary[] }>(
-    `/workspaces/${me.active_workspace_id}/agents`,
-  );
-  const agents = res.items;
+  let agents: AgentSummary[] = [];
+  let apiError: string | null = null;
+
+  try {
+    const me = await apiFetch<SessionUser>('/auth/me');
+    const res = await apiFetch<{ items: AgentSummary[] }>(
+      `/workspaces/${me.active_workspace_id}/agents`,
+    );
+    agents = res.items;
+  } catch (err) {
+    apiError = (err as Error).message;
+  }
+
+  if (apiError) {
+    return (
+      <div className="flex flex-col gap-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="font-[family-name:var(--font-serif)] text-3xl text-foreground">Agents</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Could not load agents: <code className="text-xs bg-muted px-1 py-0.5 rounded">{apiError}</code>
+            </p>
+          </div>
+          <Link href="/dashboard/agents/new">
+            <Button className="gap-2">
+              <Plus className="h-4 w-4" />
+              New agent
+            </Button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-8">

--- a/apps/web/app/dashboard/analytics/page.tsx
+++ b/apps/web/app/dashboard/analytics/page.tsx
@@ -3,7 +3,27 @@ import { AnalyticsPanel } from '@/components/analytics-panel';
 import type { SessionUser } from '@voiceforge/shared';
 
 export default async function AnalyticsPage() {
-  const me = await apiFetch<SessionUser>('/auth/me');
+  let me: SessionUser | null = null;
+  let apiError: string | null = null;
+
+  try {
+    me = await apiFetch<SessionUser>('/auth/me');
+  } catch (err) {
+    apiError = (err as Error).message;
+  }
+
+  if (apiError || !me) {
+    return (
+      <div className="flex flex-col gap-8">
+        <div>
+          <h1 className="font-[family-name:var(--font-serif)] text-3xl text-foreground">Analytics</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Could not load analytics: <code className="text-xs bg-muted px-1 py-0.5 rounded">{apiError}</code>
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-8">

--- a/apps/web/app/dashboard/billing/page.tsx
+++ b/apps/web/app/dashboard/billing/page.tsx
@@ -3,13 +3,33 @@ import { BillingPanel } from '@/components/billing-panel';
 import type { SessionUser } from '@voiceforge/shared';
 
 export default async function BillingPage() {
-  const me = await apiFetch<SessionUser>('/auth/me');
+  let me: SessionUser | null = null;
+  let apiError: string | null = null;
+
+  try {
+    me = await apiFetch<SessionUser>('/auth/me');
+  } catch (err) {
+    apiError = (err as Error).message;
+  }
 
   const priceIds = {
     starter: process.env.NEXT_PUBLIC_STRIPE_STARTER_PRICE_ID ?? null,
     growth: process.env.NEXT_PUBLIC_STRIPE_GROWTH_PRICE_ID ?? null,
     enterprise: process.env.NEXT_PUBLIC_STRIPE_ENTERPRISE_PRICE_ID ?? null,
   };
+
+  if (apiError || !me) {
+    return (
+      <div className="flex flex-col gap-8">
+        <div>
+          <h1 className="font-[family-name:var(--font-serif)] text-3xl text-foreground">Billing</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Could not load billing: <code className="text-xs bg-muted px-1 py-0.5 rounded">{apiError}</code>
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-8">

--- a/apps/web/app/dashboard/calls/page.tsx
+++ b/apps/web/app/dashboard/calls/page.tsx
@@ -6,10 +6,31 @@ import type { CallSummary, SessionUser } from '@voiceforge/shared';
 import { Phone, ArrowRight } from 'lucide-react';
 
 export default async function CallsPage() {
-  const me = await apiFetch<SessionUser>('/auth/me');
-  const { items } = await apiFetch<{ items: CallSummary[] }>(
-    `/workspaces/${me.active_workspace_id}/calls`,
-  );
+  let items: CallSummary[] = [];
+  let apiError: string | null = null;
+
+  try {
+    const me = await apiFetch<SessionUser>('/auth/me');
+    const res = await apiFetch<{ items: CallSummary[] }>(
+      `/workspaces/${me.active_workspace_id}/calls`,
+    );
+    items = res.items;
+  } catch (err) {
+    apiError = (err as Error).message;
+  }
+
+  if (apiError) {
+    return (
+      <div className="flex flex-col gap-8">
+        <div>
+          <h1 className="font-[family-name:var(--font-serif)] text-3xl text-foreground">Calls</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Could not load calls: <code className="text-xs bg-muted px-1 py-0.5 rounded">{apiError}</code>
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-8">

--- a/apps/web/app/dashboard/clients/page.tsx
+++ b/apps/web/app/dashboard/clients/page.tsx
@@ -3,7 +3,27 @@ import { ClientsPanel } from '@/components/clients-panel';
 import type { SessionUser } from '@voiceforge/shared';
 
 export default async function ClientsPage() {
-  const me = await apiFetch<SessionUser>('/auth/me');
+  let me: SessionUser | null = null;
+  let apiError: string | null = null;
+
+  try {
+    me = await apiFetch<SessionUser>('/auth/me');
+  } catch (err) {
+    apiError = (err as Error).message;
+  }
+
+  if (apiError || !me) {
+    return (
+      <div className="flex flex-col gap-8">
+        <div>
+          <h1 className="font-[family-name:var(--font-serif)] text-3xl text-foreground">Clients</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Could not load clients: <code className="text-xs bg-muted px-1 py-0.5 rounded">{apiError}</code>
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-8">

--- a/apps/web/app/dashboard/compliance/page.tsx
+++ b/apps/web/app/dashboard/compliance/page.tsx
@@ -3,7 +3,27 @@ import { CompliancePanel } from '@/components/compliance-panel';
 import type { SessionUser } from '@voiceforge/shared';
 
 export default async function CompliancePage() {
-  const me = await apiFetch<SessionUser>('/auth/me');
+  let me: SessionUser | null = null;
+  let apiError: string | null = null;
+
+  try {
+    me = await apiFetch<SessionUser>('/auth/me');
+  } catch (err) {
+    apiError = (err as Error).message;
+  }
+
+  if (apiError || !me) {
+    return (
+      <div className="flex flex-col gap-8">
+        <div>
+          <h1 className="font-[family-name:var(--font-serif)] text-3xl text-foreground">Compliance</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Could not load compliance: <code className="text-xs bg-muted px-1 py-0.5 rounded">{apiError}</code>
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-8">

--- a/apps/web/app/dashboard/integrations/page.tsx
+++ b/apps/web/app/dashboard/integrations/page.tsx
@@ -7,10 +7,39 @@ import type { SessionUser, ToolSummary } from '@voiceforge/shared';
 import { Plus, Plug, ArrowRight } from 'lucide-react';
 
 export default async function IntegrationsPage() {
-  const me = await apiFetch<SessionUser>('/auth/me');
-  const { items } = await apiFetch<{ items: ToolSummary[] }>(
-    `/workspaces/${me.active_workspace_id}/tools`,
-  );
+  let items: ToolSummary[] = [];
+  let apiError: string | null = null;
+
+  try {
+    const me = await apiFetch<SessionUser>('/auth/me');
+    const res = await apiFetch<{ items: ToolSummary[] }>(
+      `/workspaces/${me.active_workspace_id}/tools`,
+    );
+    items = res.items;
+  } catch (err) {
+    apiError = (err as Error).message;
+  }
+
+  if (apiError) {
+    return (
+      <div className="flex flex-col gap-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="font-[family-name:var(--font-serif)] text-3xl text-foreground">Integrations</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Could not load integrations: <code className="text-xs bg-muted px-1 py-0.5 rounded">{apiError}</code>
+            </p>
+          </div>
+          <Link href="/dashboard/integrations/new">
+            <Button className="gap-2">
+              <Plus className="h-4 w-4" />
+              New tool
+            </Button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-8">

--- a/apps/web/app/dashboard/knowledge/page.tsx
+++ b/apps/web/app/dashboard/knowledge/page.tsx
@@ -4,7 +4,27 @@ import type { SessionUser } from '@voiceforge/shared';
 import { BookOpen } from 'lucide-react';
 
 export default async function KnowledgePage() {
-  const me = await apiFetch<SessionUser>('/auth/me');
+  let me: SessionUser | null = null;
+  let apiError: string | null = null;
+
+  try {
+    me = await apiFetch<SessionUser>('/auth/me');
+  } catch (err) {
+    apiError = (err as Error).message;
+  }
+
+  if (apiError || !me) {
+    return (
+      <div className="flex flex-col gap-8">
+        <div>
+          <h1 className="font-[family-name:var(--font-serif)] text-3xl text-foreground">Knowledge</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Could not load knowledge: <code className="text-xs bg-muted px-1 py-0.5 rounded">{apiError}</code>
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-8">

--- a/apps/web/app/dashboard/white-label/page.tsx
+++ b/apps/web/app/dashboard/white-label/page.tsx
@@ -3,7 +3,27 @@ import { WhiteLabelPanel } from '@/components/white-label-panel';
 import type { SessionUser } from '@voiceforge/shared';
 
 export default async function WhiteLabelPage() {
-  const me = await apiFetch<SessionUser>('/auth/me');
+  let me: SessionUser | null = null;
+  let apiError: string | null = null;
+
+  try {
+    me = await apiFetch<SessionUser>('/auth/me');
+  } catch (err) {
+    apiError = (err as Error).message;
+  }
+
+  if (apiError || !me) {
+    return (
+      <div className="flex flex-col gap-8">
+        <div>
+          <h1 className="font-[family-name:var(--font-serif)] text-3xl text-foreground">White label</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Could not load settings: <code className="text-xs bg-muted px-1 py-0.5 rounded">{apiError}</code>
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-8">


### PR DESCRIPTION
## Summary

- **Backend:** Fixed Prisma P2002 unique constraint race condition in user provisioning that caused `Authentication required` on every API endpoint
- **Frontend:** Fixed 9 dashboard pages crashing with Next.js 500 server error due to unhandled `apiFetch` exceptions in SSR

## Root Causes

**1. Auth race condition (P2002)** — Clerk webhook (`user.created`) and the API request path (`findOrProvisionUser`) both try to upsert the same user concurrently. The `email` column has `@unique` in Prisma schema. The second writer hits P2002, `getSessionUser` catches it and returns `null`, `WorkspaceGuard` throws "Authentication required" on every workspace-scoped endpoint.

**2. SSR crash (500)** — 9 dashboard pages called `apiFetch('/auth/me')` bare with no try-catch. On 401, `apiFetch` throws `ApiCallError`. Unhandled in Next.js SSR → 500 "This page couldn't load". Templates and Dashboard pages worked because they already had try-catch.

## Changes

### `apps/api/src/auth/clerk-auth.service.ts`
- `findOrProvisionUser`: check by email before upsert, link orphaned records missing `externalAuthId`, catch P2002 with retry-lookup fallback

### `apps/api/src/auth/clerk-webhook.controller.ts`
- `upsertUser`: email-first lookup before upsert, P2002 catch with retry-lookup fallback

### `apps/web/app/dashboard/*/page.tsx` (9 files)
- Agents, Calls, Knowledge, Integrations, Clients, Compliance, Analytics, White label, Billing
- Wrapped `apiFetch` calls in try-catch, render graceful error state instead of crashing

## Test plan

- [x] Sign in with `deepak` / password — works
- [x] Dashboard overview renders (partial — shows API error card instead of crashing)
- [x] Templates page renders (unaffected, already had try-catch)
- [x] All 9 previously-crashing pages now render error state instead of 500
- [ ] After deploy: verify auth session builds correctly end-to-end and all pages load data

🤖 Generated with [Claude Code](https://claude.com/claude-code)